### PR TITLE
Allow for multiple csr(s) per vpc

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "aws_security_group" "gi1_sg" {
 # Create a Security Group for Cisco CSR Gi2
 resource "aws_security_group" "gi2_sg" {
   vpc_id = var.vpc_id
-  name   = "CSR GigabitEthernet2 Security Group"
+  name   = "CSR GigabitEthernet2 Security Group for ${var.csr_hostname}"
 
   dynamic "ingress" {
     for_each = local.ingress_ports

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ data "template_file" "running_config" {
 # Create a Security Group for Cisco CSR Gi1
 resource "aws_security_group" "gi1_sg" {
   vpc_id = var.vpc_id
-  name   = "CSR GigabitEthernet1 Security Group"
+  name   = "CSR GigabitEthernet1 Security Group for ${var.csr_hostname}"
 
   dynamic "ingress" {
     for_each = local.ingress_ports

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,14 +1,19 @@
 output "csr_gi1" {
-  description = "CSR GigabitEthernet1 network insterface as an object with all of it's attributes."
+  description = "CSR GigabitEthernet1 network insterface as an object with all of its attributes."
   value       = aws_network_interface.csr_gi1
 }
 
 output "csr_gi2" {
-  description = "CSR GigabitEthernet2 network insterface as an object with all of it's attributes."
+  description = "CSR GigabitEthernet2 network insterface as an object with all of its attributes."
   value       = aws_network_interface.csr_gi2
 }
 
+output "csr_eip" {
+  description = "CSR eip with all of its attributes."
+  value       = aws_eip.this
+}
+
 output "csr_instance" {
-  description = "The created CSR instance as an object with all of it's attributes."
+  description = "The created CSR instance as an object with all of its attributes."
   value       = aws_instance.this
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "csr_ami_byol_ami" {
 variable "csr_ami_sec_ami" {
   description = "Cisco Cloud Services Router (CSR) 1000V - Security Pkg. Max Performance"
   type        = string
-  default     = "cisco_CSR-17.03.05-SEC-dbfcb230-402e-49cc-857f-dacb4db08d34 "
+  default     = "cisco_CSR-17.03.06-SEC-dbfcb230-402e-49cc-857f-dacb4db08d34"
 }
 
 variable "custom_bootstrap" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 variable "csr_ami_byol_ami" {
   description = "Cisco Cloud Services Router (CSR) 1000V - BYOL for Maximum Performance"
   type        = string
-  default     = "cisco_CSR-17.03.05-BYOL-624f5bb1-7f8e-4f7c-ad2c-03ae1cd1c2d3"
+  default     = "cisco_CSR-17.03.06-BYOL-624f5bb1-7f8e-4f7c-ad2c-03ae1cd1c2d3"
 }
 
 variable "csr_ami_sec_ami" {
@@ -27,7 +27,7 @@ variable "admin_password" {
 }
 
 variable "csr_hostname" {
-  description = "Admin password for CSR"
+  description = "Csr hostname"
   type        = string
   default     = "csr1k"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -85,7 +85,7 @@ variable "egress_cidr_blocks" {
 
 locals {
   csr_bootstrap   = var.custom_bootstrap ? var.bootstrap_data : data.template_file.running_config.rendered
-  ssh_cidr_blocks = var.ssh_allow_ip != null ? var.ssh_allow_ip : ["${chomp(data.http.my_public_ip.body)}/32"]
+  ssh_cidr_blocks = var.ssh_allow_ip != null ? var.ssh_allow_ip : ["${chomp(data.http.my_public_ip.response_body)}/32"]
 
   ingress_ports = {
     "Allow SSH TCP 22" = {


### PR DESCRIPTION
Avoids security group name clash when deploying multiple csr(s) to the same vpc by appending the csr hostname to the sg name.

Also:

- Revs the csr ami as `17.03.05` is no longer available
- Switches to `response_body` over the deprecated `body` in the http resource
- Fixes csr hostname desrciption in variables
- Outputs the csr eip